### PR TITLE
Add Energy Shield auto-flask support

### DIFF
--- a/src/POE2Radar.Core/Game/Poe2Live.cs
+++ b/src/POE2Radar.Core/Game/Poe2Live.cs
@@ -155,10 +155,11 @@ public sealed class Poe2Live
     /// <summary>Player grid position (from the Render component's world position ÷ grid ratio).</summary>
     public System.Numerics.Vector2? PlayerGrid(nint localPlayer) => EntityGrid(localPlayer);
 
-    public readonly record struct Vitals(int HpCur, int HpUnreserved, int ManaCur, int ManaUnreserved)
+    public readonly record struct Vitals(int HpCur, int HpUnreserved, int ManaCur, int ManaUnreserved, int EsCur, int EsUnreserved)
     {
         public float HpPct   => HpUnreserved   > 0 ? 100f * HpCur   / HpUnreserved   : 100f;
         public float ManaPct => ManaUnreserved > 0 ? 100f * ManaCur / ManaUnreserved : 100f;
+        public float EsPct   => EsUnreserved   > 0 ? 100f * EsCur   / EsUnreserved   : 100f;
     }
 
     private nint _plLife, _plLifeFor;
@@ -218,7 +219,8 @@ public sealed class Poe2Live
         EnsureVitalOffsets(_plLife);
         if (!_reader.TryReadStruct<VitalStruct>(_plLife + _healthOff, out var hp) || hp.Max <= 0) return null;
         _reader.TryReadStruct<VitalStruct>(_plLife + _manaOff, out var mana);
-        return new Vitals(hp.Current, Unreserved(hp), mana.Current, Unreserved(mana));
+        _reader.TryReadStruct<VitalStruct>(_plLife + Poe2.Life.EnergyShield, out var es);
+        return new Vitals(hp.Current, Unreserved(hp), mana.Current, Unreserved(mana), es.Current, Unreserved(es));
     }
 
     private static int Unreserved(VitalStruct v)

--- a/src/POE2Radar.Overlay/Config/RadarSettings.cs
+++ b/src/POE2Radar.Overlay/Config/RadarSettings.cs
@@ -65,7 +65,7 @@ public sealed class RadarSettings
     // ── Auto-flask thresholds + per-flask cooldowns (milliseconds). ──
     public float LifeThresholdPct { get; set; } = 65f;
     public float ManaThresholdPct { get; set; } = 30f;
-    public float EsThresholdPct { get; set; } = 50f;
+    public float EsThresholdPct { get; set; } = 0f;
     public int LifeCooldownMs { get; set; } = 2500;
     public int ManaCooldownMs { get; set; } = 2000;
     public int EsCooldownMs { get; set; } = 1000;

--- a/src/POE2Radar.Overlay/Config/RadarSettings.cs
+++ b/src/POE2Radar.Overlay/Config/RadarSettings.cs
@@ -65,12 +65,15 @@ public sealed class RadarSettings
     // ── Auto-flask thresholds + per-flask cooldowns (milliseconds). ──
     public float LifeThresholdPct { get; set; } = 65f;
     public float ManaThresholdPct { get; set; } = 30f;
+    public float EsThresholdPct { get; set; } = 50f;
     public int LifeCooldownMs { get; set; } = 2500;
     public int ManaCooldownMs { get; set; } = 2000;
+    public int EsCooldownMs { get; set; } = 1000;
 
-    // ── Flask key codes (Win32 virtual-key). Defaults: '1' = life, '2' = mana. ──
+    // ── Flask key codes (Win32 virtual-key). Defaults: '1' = life, '2' = mana, '1' = ES. ──
     public int LifeKey { get; set; } = 0x31;
     public int ManaKey { get; set; } = 0x32;
+    public int EsKey { get; set; } = 0x31;
 
     // ── HTTP API. ──
     public int ApiPort { get; set; } = 7777;

--- a/src/POE2Radar.Overlay/RadarApp.cs
+++ b/src/POE2Radar.Overlay/RadarApp.cs
@@ -53,13 +53,13 @@ public sealed class RadarApp : IDisposable
     private volatile bool _shutdown;
 
     // ── Auto-flask (opt-in input). Foreground + in-game gated; F8 master kill-switch.
-    //    Flask keys are configurable in RadarSettings (LifeKey/ManaKey). ──
+    //    Flask keys are configurable in RadarSettings (LifeKey/ManaKey/EsKey). ──
     private bool _autoFlask = true;                        // auto-on; toggle with F8
-    private DateTime _lifeFiredAt = DateTime.MinValue, _manaFiredAt = DateTime.MinValue;
+    private DateTime _lifeFiredAt = DateTime.MinValue, _manaFiredAt = DateTime.MinValue, _esFiredAt = DateTime.MinValue;
     private DateTime _nextToggleAt = DateTime.MinValue;
     private DateTime _nextPathKeyAt = DateTime.MinValue;
     private DateTime _nextBrowserAt = DateTime.MinValue;
-    private float _hpPct = 100f, _manaPct = 100f;
+    private float _hpPct = 100f, _manaPct = 100f, _esPct = 100f;
     private string _flaskNote = "";
     private string _areaCode = "", _charName = "";
     private int _charLevel;
@@ -324,7 +324,7 @@ public sealed class RadarApp : IDisposable
         }
 
         _state = new RadarState(inGame, _areaHash, areaLevel, map.IsVisible, map.Zoom, player, _entities, _landmarks,
-            _hpPct, _manaPct, _autoFlask, _flaskNote, _areaCode, _charName, _charLevel);
+            _hpPct, _manaPct, _esPct, _autoFlask, _flaskNote, _areaCode, _charName, _charLevel);
 
         var ctx = new RenderContext(
             InGame: inGame,
@@ -460,7 +460,7 @@ public sealed class RadarApp : IDisposable
             _flaskNote = "paused (vitals unreadable — offsets may have drifted)";
             return;
         }
-        _hpPct = v.HpPct; _manaPct = v.ManaPct;
+        _hpPct = v.HpPct; _manaPct = v.ManaPct; _esPct = v.EsPct;
 
         if (!_autoFlask) { _flaskNote = "OFF (F8)"; return; }
         if (GetForegroundWindow() != _gameHwnd) { _flaskNote = "paused (PoE2 not focused)"; return; }
@@ -476,6 +476,11 @@ public sealed class RadarApp : IDisposable
             now - _manaFiredAt >= TimeSpan.FromMilliseconds(_settings.ManaCooldownMs))
         {
             SendInputNative.Tap((ushort)_settings.ManaKey); _manaFiredAt = now; _flaskNote = $"mana@{v.ManaPct:F0}%";
+        }
+        if (v.EsUnreserved > 0 && v.EsPct < _settings.EsThresholdPct &&
+            now - _esFiredAt >= TimeSpan.FromMilliseconds(_settings.EsCooldownMs))
+        {
+            SendInputNative.Tap((ushort)_settings.EsKey); _esFiredAt = now; _flaskNote = $"es@{v.EsPct:F0}%";
         }
     }
 

--- a/src/POE2Radar.Overlay/Web/ApiServer.cs
+++ b/src/POE2Radar.Overlay/Web/ApiServer.cs
@@ -125,7 +125,7 @@ public sealed class ApiServer : IDisposable
                     areaName = ZoneGuide.Shared.FriendlyName(s.AreaCode),
                     areaAct = ZoneGuide.Shared.Area(s.AreaCode)?.Act ?? 0,
                     mapVisible = s.MapVisible, zoom = s.Zoom,
-                    hpPct = s.HpPct, manaPct = s.ManaPct, autoFlask = s.AutoFlask, flask = s.FlaskNote,
+                    hpPct = s.HpPct, manaPct = s.ManaPct, esPct = s.EsPct, autoFlask = s.AutoFlask, flask = s.FlaskNote,
                     player = new { x = s.Player.X, y = s.Player.Y },
                     entityCount = s.Entities.Count,
                     poiCount = s.Entities.Count(e => e.Poi),
@@ -370,10 +370,13 @@ public sealed class ApiServer : IDisposable
         offY = _settings.OffY,
         lifeThresholdPct = _settings.LifeThresholdPct,
         manaThresholdPct = _settings.ManaThresholdPct,
+        esThresholdPct = _settings.EsThresholdPct,
         lifeCooldownMs = _settings.LifeCooldownMs,
         manaCooldownMs = _settings.ManaCooldownMs,
+        esCooldownMs = _settings.EsCooldownMs,
         lifeKey = _settings.LifeKey,
         manaKey = _settings.ManaKey,
+        esKey = _settings.EsKey,
         apiPort = _settings.ApiPort, // display only — changing it needs a restart
         styles = _settings.Styles,   // per-item icon shapes/colors/sizes + mechanic overrides
         hpBars = _settings.HpBars,   // monster HP-bar geometry (width/height/offset)
@@ -411,10 +414,13 @@ public sealed class ApiServer : IDisposable
                 case "hpBarUnique" when TryBool(p.Value, out var b): _settings.HpBarUnique = b; applied.Add(p.Name); break;
                 case "lifeThresholdPct" when TryFloat(p.Value, out var f): _settings.LifeThresholdPct = Math.Clamp(f, 0f, 100f); applied.Add(p.Name); break;
                 case "manaThresholdPct" when TryFloat(p.Value, out var f): _settings.ManaThresholdPct = Math.Clamp(f, 0f, 100f); applied.Add(p.Name); break;
+                case "esThresholdPct" when TryFloat(p.Value, out var f): _settings.EsThresholdPct = Math.Clamp(f, 0f, 100f); applied.Add(p.Name); break;
                 case "lifeCooldownMs" when TryInt(p.Value, out var n): _settings.LifeCooldownMs = Math.Clamp(n, 0, 60000); applied.Add(p.Name); break;
                 case "manaCooldownMs" when TryInt(p.Value, out var n): _settings.ManaCooldownMs = Math.Clamp(n, 0, 60000); applied.Add(p.Name); break;
+                case "esCooldownMs" when TryInt(p.Value, out var n): _settings.EsCooldownMs = Math.Clamp(n, 0, 60000); applied.Add(p.Name); break;
                 case "lifeKey" when TryInt(p.Value, out var n): _settings.LifeKey = Math.Clamp(n, 1, 255); applied.Add(p.Name); break;
                 case "manaKey" when TryInt(p.Value, out var n): _settings.ManaKey = Math.Clamp(n, 1, 255); applied.Add(p.Name); break;
+                case "esKey" when TryInt(p.Value, out var n): _settings.EsKey = Math.Clamp(n, 1, 255); applied.Add(p.Name); break;
                 // Whole-object writes (the dashboard re-POSTs the full sub-object on edit). Parsed,
                 // sanitized/clamped, then swapped in. A malformed sub-object is skipped, not fatal.
                 case "styles" when p.Value.ValueKind == JsonValueKind.Object:
@@ -781,6 +787,7 @@ public sealed record RadarState(
     IReadOnlyList<Poe2Live.Landmark> Landmarks,
     float HpPct,
     float ManaPct,
+    float EsPct,
     bool AutoFlask,
     string FlaskNote,
     string AreaCode,
@@ -789,5 +796,5 @@ public sealed record RadarState(
 {
     public static readonly RadarState Empty =
         new(false, 0, 0, false, 0, System.Numerics.Vector2.Zero,
-            Array.Empty<Poe2Live.EntityDot>(), Array.Empty<Poe2Live.Landmark>(), 100, 100, false, "", "", "", 0);
+            Array.Empty<Poe2Live.EntityDot>(), Array.Empty<Poe2Live.Landmark>(), 100, 100, 100, false, "", "", "", 0);
 }

--- a/src/POE2Radar.Overlay/Web/DashboardHtml.cs
+++ b/src/POE2Radar.Overlay/Web/DashboardHtml.cs
@@ -255,6 +255,12 @@ internal static class DashboardHtml
   .hpshared .numin{width:62px}
   .delbtn{font-family:inherit; font-size:11px; color:var(--blood-bright); background:transparent; border:1px solid var(--line); border-radius:2px; padding:4px 9px; cursor:pointer; flex:none}
   .trow-ctl{display:flex; align-items:center; gap:9px; flex:none}
+  /* auto-flask 3-resource table: Resource | Threshold % | Flask key | Cooldown ms */
+  .flask-grid{display:grid; grid-template-columns:90px 1fr 1fr 1fr; gap:7px 10px; align-items:center; padding:4px 0 6px}
+  .flask-grid .fgh{font-size:9px; letter-spacing:.06em; text-transform:uppercase; color:var(--ink-faint); text-align:center}
+  .flask-grid .fgh:first-child{text-align:left}
+  .flask-grid .fgr{font-size:12px; color:var(--ink)}
+  .flask-grid .numin{width:100%; min-width:0; padding:5px 8px}
 
   /* ── SVG icon picker (replaces the plain shape <select>): a button showing the chosen icon's
        silhouette + name, opening a shared popup grid of icon previews. ── */
@@ -484,18 +490,25 @@ internal static class DashboardHtml
           </div>
           <div class="card">
             <h3>Auto-Flask</h3>
-            <div class="row"><div class="rl">Life threshold %<small>tap life flask below this Life %</small></div>
-              <input class="numin" type="number" step="1" min="0" max="100" data-set="lifeThresholdPct"></div>
-            <div class="row"><div class="rl">Mana threshold %<small>tap mana flask below this Mana %</small></div>
-              <input class="numin" type="number" step="1" min="0" max="100" data-set="manaThresholdPct"></div>
-            <div class="row"><div class="rl">Life flask key</div>
-              <input class="numin keyin" type="text" maxlength="1" data-set="lifeKey"></div>
-            <div class="row"><div class="rl">Mana flask key</div>
-              <input class="numin keyin" type="text" maxlength="1" data-set="manaKey"></div>
-            <div class="row"><div class="rl">Life cooldown<small>min ms between life taps</small></div>
-              <input class="numin" type="number" step="100" min="0" data-set="lifeCooldownMs"></div>
-            <div class="row"><div class="rl">Mana cooldown<small>min ms between mana taps</small></div>
-              <input class="numin" type="number" step="100" min="0" data-set="manaCooldownMs"></div>
+            <div class="flask-grid">
+              <div class="fgh"></div>
+              <div class="fgh">Threshold %</div>
+              <div class="fgh">Flask key</div>
+              <div class="fgh">Cooldown ms</div>
+              <div class="fgr">Life</div>
+              <input class="numin" type="number" step="1" min="0" max="100" data-set="lifeThresholdPct">
+              <input class="numin keyin" type="text" maxlength="1" data-set="lifeKey">
+              <input class="numin" type="number" step="100" min="0" data-set="lifeCooldownMs">
+              <div class="fgr">Mana</div>
+              <input class="numin" type="number" step="1" min="0" max="100" data-set="manaThresholdPct">
+              <input class="numin keyin" type="text" maxlength="1" data-set="manaKey">
+              <input class="numin" type="number" step="100" min="0" data-set="manaCooldownMs">
+              <div class="fgr">Energy Shield</div>
+              <input class="numin" type="number" step="1" min="0" max="100" data-set="esThresholdPct">
+              <input class="numin keyin" type="text" maxlength="1" data-set="esKey">
+              <input class="numin" type="number" step="100" min="0" data-set="esCooldownMs">
+            </div>
+            <div class="row"><div class="rl hint-row"><b>Threshold %</b> &mdash; flask fires when the resource drops below this value; clear (or set to 0) to disable that resource. <b>Flask key</b> &mdash; the key pressed when triggered (1&ndash;9 or a letter). <b>Cooldown ms</b> &mdash; minimum time between repeats for that resource. Energy Shield only triggers when ES is present.</div></div>
             <div class="row"><div class="rl hint-row">F8 toggles auto-flask in-game. Status: <span id="flaskState">&mdash;</span></div></div>
           </div>
         </div>


### PR DESCRIPTION
## Summary

Extends the auto-flask system to monitor Energy Shield in addition to Life and Mana.
<img width="373" height="379" alt="image" src="https://github.com/user-attachments/assets/dbd42bef-21ae-474f-8388-af65baaa493c" />


## Changes

### `POE2Radar.Core` — `Poe2Live.cs`
- Extended the `Vitals` record with `EsCur` / `EsUnreserved` fields and an `EsPct` computed property.
- `PlayerVitals` now reads the ES `VitalStruct` at `Poe2.Life.EnergyShield` (offset `0x248`, already validated in `Poe2Offsets.cs`).

### `POE2Radar.Overlay` — `Config/RadarSettings.cs`
- Added three new persisted settings with defaults matching the request:
  - `EsThresholdPct = 0` — disabled by default
  - `EsCooldownMs = 1000` — 1 s between repeats
  - `EsKey = 0x31` — flask key `1` (same as Life by default)

### `POE2Radar.Overlay` — `RadarApp.cs`
- Added `_esFiredAt` and `_esPct` state fields.
- `TickAutoFlask` fires the ES flask key when `EsUnreserved > 0` (ES present on the build) and `EsPct` drops below the threshold, gated by the cooldown.
- `RadarState` construction passes `_esPct`.

### `POE2Radar.Overlay` — `Web/ApiServer.cs`
- `RadarState` record: added `float EsPct`.
- `/state` response: exposes `esPct`.
- `ReadSettings`: exposes `esThresholdPct` / `esCooldownMs` / `esKey`.
- `ApplySettings`: handles all three as writable, clamped settings.

### `POE2Radar.Overlay` — `Web/DashboardHtml.cs`
- Replaced the flat Auto-Flask list with a compact **3-row grid table** (Resource | Threshold % | Flask key | Cooldown ms) covering Life, Mana, and Energy Shield.
- Added a help/hint row explaining each column and the ES-only-when-present behaviour.